### PR TITLE
magit-imerge-continue: run git asynchronously

### DIFF
--- a/magit-imerge.el
+++ b/magit-imerge.el
@@ -283,7 +283,7 @@ plan to return to this incremental merge later."
   (magit-imerge--assert-in-progress)
   (if (magit-anything-unstaged-p t)
       (user-error "Cannot continue with unstaged changes")
-    (magit-run-git "imerge" "continue" "--no-edit")))
+    (magit-run-git-async "imerge" "continue" "--no-edit")))
 
 (defun magit-imerge--insert-tip (tip)
   ;; The order of these checks follows the same tag > local branch >


### PR DESCRIPTION
Any reason not to make it async? I've used this for a big merge, and having Emacs locked while waiting for the auto-filling was pretty annoying. I set it to use async part-way through, and it was much more pleasant after that.